### PR TITLE
chore: Sanitize error message in AWS Lambda handler

### DIFF
--- a/aws/lambda/app.js
+++ b/aws/lambda/app.js
@@ -32,8 +32,9 @@ exports.handler = async (event) => {
     })
   })
 
-  req.on('error', error => {
-    console.error(error)
+req.on('error', error => {
+    const sanitizedError = error.toString().replace(/[\r\n]+/g, ' '); // Basic sanitization
+    console.error(sanitizedError);
     response = {
       statusCode: 500,
       body: JSON.stringify("An error occurred: " + error.message),


### PR DESCRIPTION
This pull request includes a change in the error handling section of the `aws/lambda/app.js` file. The change introduces basic sanitization to the error message before logging it to the console. This is done by replacing newline characters in the error message with a space.

### Changes.

- `aws/lambda/app.js`: Sanitize error message in the `req.on('error', error => {` method by replacing newline characters with a space.



